### PR TITLE
iOS - Fix loading of the playerUiJs

### DIFF
--- a/ios/RNBitmovinPlayer.m
+++ b/ios/RNBitmovinPlayer.m
@@ -92,7 +92,7 @@
         NSLog(@"uiJs: url: %@, contents: \n%@",url, content);
         */
 
-        configuration.styleConfiguration.supplementalPlayerUiCss = url;
+        configuration.styleConfiguration.playerUiJs = url;
     }
 
 


### PR DESCRIPTION
Now loads the playerUiJs correctly, adding the missing subtitle settings.